### PR TITLE
Add missing require

### DIFF
--- a/lib/ruby_memprofiler_pprof/file_flusher.rb
+++ b/lib/ruby_memprofiler_pprof/file_flusher.rb
@@ -2,6 +2,7 @@
 
 require "fileutils"
 require "forwardable"
+require "time"
 
 module MemprofilerPprof
   class FileFlusher


### PR DESCRIPTION
`Time#iso8601` is only actually loaded once you `require 'time'`.

It's common to forget to do so because often something else in the system will have done it already; but I was experimenting with a tiny app and ran into the issue.

```
$ ruby -e 'puts Time.now.iso8601'
-e:1:in `<main>': undefined method `iso8601' for 2022-08-29 15:30:07.114482 +0100:Time (NoMethodError)
$ ruby -e 'require "time"; puts Time.now.iso8601'
2022-08-29T15:30:18+01:00
```