### PR TITLE
Cleanup CI config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Test
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   test:
     name: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,20 +17,7 @@ jobs:
       - uses: zendesk/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: setup_env
-        run: |
-          echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/Gemfile" >> $GITHUB_ENV
-        shell: bash
-      - name: gem_cache
-        id: cache
-        uses: zendesk/cache@v2
-        with:
-          path: vendor/bundle
-          key: cache-${{ runner.os }}-ruby-${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock') }}
-      - name: install_gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install
+          bundler-cache: true
       - name: compile
         run: |
           bundle exec rake compile VERBOSE=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           - '3.0'
           - '3.1'
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: zendesk/checkout@v3
       - uses: zendesk/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_memprofiler_pprof (0.0.4.dev)
+    ruby_memprofiler_pprof (0.0.4)
       backtracie (= 1.0.0)
 
 GEM


### PR DESCRIPTION
1. Use bundler-cache to remove unnecessary config
2. Ensure CI runs on PRs from forks:

In an open source project like this, contributors will typically create a fork of the repository, create a new branch, push to that branch and open a pull request on the “main” repository. In that workflow, the `push` event happens on the forked repository while `pull_request` events happen on the main repository. If we want CI results visible in the pull request, we need the jobs to run in the main repository, hence we must run this workflow on the `pull_request` event. (See how CI didn’t run in #6).

Since we still also want CI to run whenever something is pushed to the main branch, e.g. when a pull request is merged, we configure CI to run on `push → branches → main` too.
