### PR TITLE
Enable the Ruby linter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,15 @@
 name: Test
 on: push
 jobs:
+  lint:
+    name: standard
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: zendesk/checkout@v3
+      - uses: zendesk/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec standardrb
   test:
     name: test
     runs-on: ubuntu-20.04
@@ -13,7 +22,7 @@ jobs:
           - '3.0'
           - '3.1'
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: zendesk/checkout@v3
       - uses: zendesk/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -1,0 +1,14 @@
+# Auto generated files with errors to ignore.
+# Remove from this list as you refactor files.
+---
+ignore:
+- ext/ruby_memprofiler_pprof_ext/extconf.rb:
+  - Style/GlobalVars
+- script/benchmark.rb:
+  - Style/GlobalVars
+- script/benchmark_isolated.rb:
+  - Style/GlobalVars
+- test/test_helper.rb:
+  - Style/MissingRespondToMissing
+- test/test_profiling.rb:
+  - Style/GlobalVars

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "bundler/gem_tasks"
 require "rake/extensiontask"
 require "rake/testtask"
+require "standard/rake"
 require "bump/tasks"
 
 # Compile verbosely if specified.
@@ -17,7 +18,7 @@ Rake::TestTask.new(:test) do |t|
   t.warning = false
 end
 
-task default: [:compile]
+task default: [:compile, :test, "standard:fix"]
 
 # These Rake tasks run the protobuf compiler to generate the .upb.c code. These are not run as part of
 # the gem install; the generated protobufs are actually checked in. We also check in a complete copy

--- a/ext/ruby_memprofiler_pprof_ext/extconf.rb
+++ b/ext/ruby_memprofiler_pprof_ext/extconf.rb
@@ -144,7 +144,7 @@ $VPATH << "$(srcdir)/vendor/upb/third_party/utf8_range"
 $INCFLAGS << " -I#{File.join($srcdir, "vendor/upb")}"
 
 # Include the vendored Backtracie header too
-$INCFLAGS << " -I#{File.join($srcdir, 'vendor/backtracie')}"
+$INCFLAGS << " -I#{File.join($srcdir, "vendor/backtracie")}"
 
 dir_config("ruby")
 

--- a/lib/ruby_memprofiler_pprof.rb
+++ b/lib/ruby_memprofiler_pprof.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'backtracie'
+require "backtracie"
 require "ruby_memprofiler_pprof/version"
 require "ruby_memprofiler_pprof/profile_data"
 require "ruby_memprofiler_pprof_ext"

--- a/lib/ruby_memprofiler_pprof/profile_data.rb
+++ b/lib/ruby_memprofiler_pprof/profile_data.rb
@@ -5,7 +5,7 @@ module MemprofilerPprof
     attr_accessor :pprof_data, :heap_samples_count, :dropped_samples_heap_bufsize,
       :flush_duration_nsecs, :pprof_serialization_nsecs, :sample_add_nsecs,
       :sample_add_without_gvl_nsecs,
-      :gvl_proactive_yield_count, :gvl_proactive_check_yield_count,
+      :gvl_proactive_yield_count, :gvl_proactive_check_yield_count
 
     def to_s
       "<MemprofilerPprof::ProfileData:#{object_id.to_s(16)} (sample counts: " \

--- a/ruby_memprofiler_pprof.gemspec
+++ b/ruby_memprofiler_pprof.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
 
   # This incredibly tight pin on backtracie is required, because we're calling its C internals via
   # a header file we vendored. Upgrading this requires copoying a new version of the header file.
-  spec.add_dependency 'backtracie', '= 1.0.0'
+  spec.add_dependency "backtracie", "= 1.0.0"
 end


### PR DESCRIPTION
Please consider this PR blocked by #7.

The standardrb gem was already required in Gemfile, but it doesn't seem to have been run too often.

With this commit, standardrb is run when you run `rake` (along with :test), and standardrb is now also run on CI.

Please note that `bundle exec standardrb --generate-todo` created a TODO file that I have minimized as much as possible, but there are still some complaints about global variables and whatnot.